### PR TITLE
Allow rendering of RootEngine results onto Node outputs

### DIFF
--- a/docs/docs/NodeEditor.mdx
+++ b/docs/docs/NodeEditor.mdx
@@ -93,3 +93,7 @@ Optional. Can be one of 3 possible values:
 - `prevent`: Default. When a user attempts to connect nodes in a way that would create a circular graph, the connection is rejected and a warning is displayed.
 - `warn`: Creating circular connections is allowed, but a warning is displayed.
 - `allow`: Creating circular connections is allowed without a warning.
+
+### `resolvedValues` : object
+
+Optional. If you set this to the result of running the `RootEngine.resolveAllNodes` function, then you can display the output values from each node by adding a `renderResult` function to your `addPortType` calls.

--- a/docs/docs/RootEngine.mdx
+++ b/docs/docs/RootEngine.mdx
@@ -112,6 +112,10 @@ A function which accepts a set of nodes created through the node editor, and an 
 This method must be called with nodes having exactly one root node. If multiple root nodes are found, the first root node found will be used. In most cases this is not a desired behavior. If you need to support multiple root nodes you should manually keep track of their node ids, and resolve them seperately by passing their ids to the `rootNodeId` key of the options object, as described below.
 :::
 
+## `resolveAllNodes` : method
+
+A function which accepts a set of nodes created through the node editor, and an optional `options` object; and returns an object representing all outputs of all nodes.
+
 ### `options` : object
 
 A configuration object representing settings for the requested resolution of the root node.

--- a/docs/docs/flume-config.mdx
+++ b/docs/docs/flume-config.mdx
@@ -90,6 +90,21 @@ Optional. An array of controls that will be displayed to the user when this port
 While this key is optional, it is rare that you will need to create a port without any controls.
 :::
 
+### `renderResult` : function
+
+Optional. Used to render the resolvedValues from a RootEngine next to each output.
+
+```js
+config
+  .addPortType({
+    type: "color",
+    name: "color",
+    label: "Color",
+    controls: [...],
+    renderResult: (color) => <span style={{color}}>{color}</span>
+  })
+```
+
 ## `addNodeType` : method(nodeType)
 
 This method allows you to add a new node type to your config.

--- a/src/RootEngine.js
+++ b/src/RootEngine.js
@@ -13,6 +13,7 @@ export class RootEngine {
     this.resolveInputControls = resolveInputControls;
     this.loops = 0;
     this.maxLoops = 1000;
+    this.resultCache = {};
   }
   resetLoops = maxLoops => {
     this.maxLoops = maxLoops !== undefined ? maxLoops : 1000;
@@ -81,8 +82,9 @@ export class RootEngine {
       inputValues,
       outputNodeType,
       context
-    )[connection.portName];
-    return outputResult;
+    );
+    this.resultCache[connection.nodeId] = outputResult;
+    return outputResult[connection.portName];
   };
   resolveRootNode(nodes, options = {}) {
     const rootNode = options.rootNodeId
@@ -140,5 +142,18 @@ export class RootEngine {
       );
       return {};
     }
+  }
+  resolveAllNodes(nodes, options = {}) {
+    this.resultCache = {};
+    Object.keys(nodes).forEach((key) => {
+      this.getValueOfConnection(
+        {nodeId: key, portName: ''},
+        nodes,
+        options.context || {}
+      )
+    });
+    const resultCache = this.resultCache;
+    this.resultCache = {};
+    return resultCache;
   }
 }

--- a/src/components/IoPorts/IoPorts.js
+++ b/src/components/IoPorts/IoPorts.js
@@ -48,7 +48,8 @@ const IoPorts = ({
   outputs = [],
   connections,
   inputData,
-  updateNodeConnections
+  updateNodeConnections,
+  resolvedValues
 }) => {
   const inputTypes = React.useContext(PortTypesContext);
   const triggerRecalculation = React.useContext(ConnectionRecalculateContext);
@@ -84,6 +85,7 @@ const IoPorts = ({
               nodeId={nodeId}
               inputData={inputData}
               portOnRight
+              resolvedValue={resolvedValues && resolvedValues[output.name]}
               key={output.name}
             />
           ))}
@@ -177,9 +179,13 @@ const Output = ({
   nodeId,
   type,
   inputTypes,
-  triggerRecalculation
+  triggerRecalculation,
+  renderResult: localRenderResult,
+  resolvedValue,
 }) => {
-  const { label: defaultLabel, color } = inputTypes[type] || {};
+  const { label: defaultLabel, color, renderResult: defaultRenderResult } = inputTypes[type] || {};
+
+  const renderResult = localRenderResult || defaultRenderResult;
 
   return (
     <div
@@ -190,7 +196,10 @@ const Output = ({
         e.stopPropagation();
       }}
     >
-      <label className={styles.portLabel}>{label || defaultLabel}</label>
+      {!renderResult && (
+        <label className={styles.portLabel}>{label || defaultLabel}</label>
+      )}
+      {renderResult && renderResult(resolvedValue)}
       <Port
         type={type}
         name={name}

--- a/src/components/Node/Node.js
+++ b/src/components/Node/Node.js
@@ -25,7 +25,8 @@ const Node = ({
   inputData,
   onDragStart,
   onDragEnd,
-  onDrag
+  onDrag,
+  resolvedValues
 }) => {
   const cache = React.useContext(CacheContext);
   const nodeTypes = React.useContext(NodeTypesContext);
@@ -179,6 +180,7 @@ const Node = ({
         connections={connections}
         updateNodeConnections={updateNodeConnections}
         inputData={inputData}
+        resolvedValues={resolvedValues}
       />
       {menuOpen ? (
         <Portal>

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,8 @@ export let NodeEditor = (
     disableZoom = false,
     disablePan = false,
     circularBehavior,
-    debug
+    debug,
+    resolvedValues = {}
   },
   ref
 ) => {
@@ -209,6 +210,7 @@ export let NodeEditor = (
                             stageRect={stage}
                             onDragEnd={triggerRecalculation}
                             onDragStart={recalculateStageRect}
+                            resolvedValues={resolvedValues[node.id]}
                             key={node.id}
                           />
                         ))}

--- a/src/typeBuilders.js
+++ b/src/typeBuilders.js
@@ -243,7 +243,8 @@ export class FlumeConfig {
       name: config.name,
       label: define(config.label, ""),
       color: define(config.color, Colors.grey),
-      hidePort: define(config.hidePort, false)
+      hidePort: define(config.hidePort, false),
+      renderResult: config.renderResult
     };
 
     if (config.acceptTypes === undefined) {


### PR DESCRIPTION
After resolving nodes using the root engine, this pull request allows those results to be rendered back onto nodes